### PR TITLE
Better group handling

### DIFF
--- a/bin/xcmv
+++ b/bin/xcmv
@@ -51,7 +51,7 @@ dst = ARGV.pop
 if dst.directory?
   ARGV.each do |src|
     src_file = src.directory? ? XcodeMove::Group.new(src) : XcodeMove::File.new(src)
-    dst_file = src_file.corresponding_dst(dst)
+    dst_file = src_file.with_dirname(dst)
     XcodeMove.mv(src_file, dst_file, options)
   end
 else

--- a/bin/xcmv
+++ b/bin/xcmv
@@ -50,11 +50,12 @@ ARGV.map!{ |a| Pathname.new(a) }
 dst = ARGV.pop
 if dst.directory?
   ARGV.each do |src|
-    dst_file = dst + src.basename
-    XcodeMove.mv(XcodeMove::File.new(src), XcodeMove::File.new(dst_file), options)
+    src_file = src.directory? ? XcodeMove::Group.new(src) : XcodeMove::File.new(src)
+    dst_file = src_file.corresponding_dst(dst)
+    XcodeMove.mv(src_file, dst_file, options)
   end
 else
-  if ARGV.count > 2
+  if ARGV.count > 2 || ARGV[0].directory?
     abort "Error: moving more than one file to #{dst}\n" + parser.help
   end
   src = ARGV[0]

--- a/bin/xcmv
+++ b/bin/xcmv
@@ -50,14 +50,12 @@ ARGV.map!{ |a| Pathname.new(a) }
 dst = ARGV.pop
 if dst.directory?
   ARGV.each do |src|
-    src_file = src.directory? ? XcodeMove::Group.new(src) : XcodeMove::File.new(src)
-    dst_file = src_file.with_dirname(dst)
-    XcodeMove.mv(src_file, dst_file, options)
+    XcodeMove.mv(src, dst, options)
   end
 else
   if ARGV.count > 2 || ARGV[0].directory?
     abort "Error: moving more than one file to #{dst}\n" + parser.help
   end
   src = ARGV[0]
-  XcodeMove.mv(XcodeMove::File.new(src), XcodeMove::File.new(dst), options)
+  XcodeMove.mv(src, dst, options)
 end

--- a/bin/xcmv
+++ b/bin/xcmv
@@ -60,4 +60,3 @@ else
   src = ARGV[0]
   XcodeMove.mv(XcodeMove::File.new(src), XcodeMove::File.new(dst), options)
 end
-

--- a/lib/xcmv.rb
+++ b/lib/xcmv.rb
@@ -8,34 +8,51 @@ require_relative 'xcmv/version'
 module XcodeMove
 
   # Moves from one `XcodeMove::File` to another
-  def self.mv(src, dst, options)
-    puts("#{src.path} => #{dst.path}")
+  def self.mv(src, dst, options, indent=0)
+    puts("#{"  " * indent}#{src.path} => #{dst.path}")
 
-    # Remove files from xcodeproj (including dst if the file is being overwritten)
-    if src.pbx_file
+    if src.path.directory?
+      # Process all children first
+      children = src.path.children.map { |c| c.directory? ? Group.new(c) : File.new(c) }
+      children.each do | c |
+        dst_file = c.corresponding_dst(dst.path)
+        XcodeMove.mv(c, dst_file, options, indent + 1)
+      end
+
+      # Remove src group from project
       src.remove_from_project
+
+      # Remove src group from disk
+      remover = "rmdir"
+      command = "#{remover} '#{src.path}'"
+      system(command) || abort
     else
-      warn("warning: #{src.path.basename} not found in #{src.project.path.basename}. moving anyway...")
-    end
-    if dst.pbx_file
-      dst.remove_from_project
-    end
+      # Remove files from xcodeproj (including dst if the file is being overwritten)
+      if src.pbx_file
+        src.remove_from_project
+      else
+        warn("warning: #{src.path.realdirpath} not found in #{src.project.path.basename}. moving anyway...")
+      end
+      if dst.pbx_file
+        dst.remove_from_project
+      end
 
-    # Add to the new xcodeproj
-    dst.create_file_reference
-    dst.add_to_targets(options[:targets], options[:headers])
+      # Add to the new xcodeproj
+      dst.create_file_reference
+      dst.add_to_targets(options[:targets], options[:headers])
 
-    # Move the actual file
-    if options[:git]
-      mover = "git mv"
-    else 
-      mover = "mv"
+      # Move the actual file
+      if options[:git]
+        mover = "git mv"
+      else 
+        mover = "mv"
+      end
+      command = "#{mover} '#{src.path}' '#{dst.path}'"
+      system(command) || abort
+
+      # Save
+      src.save_and_close
+      dst.save_and_close
     end
-    command = "#{mover} '#{src.path}' '#{dst.path}'"
-    system(command) || abort
-
-    # Save
-    src.save_and_close
-    dst.save_and_close
   end
 end

--- a/lib/xcmv.rb
+++ b/lib/xcmv.rb
@@ -15,7 +15,7 @@ module XcodeMove
       # Process all children first
       children = src.path.children.map { |c| c.directory? ? Group.new(c) : File.new(c) }
       children.each do | c |
-        dst_file = c.corresponding_dst(dst.path)
+        dst_file = c.with_dirname(dst.path)
         XcodeMove.mv(c, dst_file, options, indent + 1)
       end
 

--- a/lib/xcmv.rb
+++ b/lib/xcmv.rb
@@ -14,9 +14,9 @@ module XcodeMove
 
     puts("#{src_file.path} => #{dst_file.path}")
 
-    XcodeMove.project_mv(src_file, dst_file, options)
-    XcodeMove.disk_mv(src_file, dst_file, options)
-    XcodeMove.save(src_file, dst_file)
+    project_mv(src_file, dst_file, options)
+    disk_mv(src_file, dst_file, options)
+    save(src_file, dst_file)
   end
 
   private
@@ -28,7 +28,7 @@ module XcodeMove
       children = src_file.path.children.map { |c| c.directory? ? Group.new(c) : File.new(c) }
       children.each do | src_child |
         dst_child = src_child.with_dirname(dst_file.path)
-        XcodeMove.project_mv(src_child, dst_child, options)
+        project_mv(src_child, dst_child, options)
       end
     else
       # Remove old destination file reference if it exists

--- a/lib/xcmv/file.rb
+++ b/lib/xcmv/file.rb
@@ -19,7 +19,11 @@ module XcodeMove
     def header?
       path.extname == '.h'
     end
-    
+
+    def corresponding_dst(root_dst_path)
+      dst_path = root_dst_path + path.basename
+      self.class.new(dst_path) # want to return the same kind of object as the source
+    end
 
     # Traverses up from the `path` to enumerate over xcodeproj directories
     def reachable_projects
@@ -96,23 +100,25 @@ module XcodeMove
     end
   end
 
-  class Directory < File
+  class Group < File
+    def initialize(path)
+      path = Pathname.new path
+      # need to create directories if they don't exist!
+      if not path.exist?
+        path.mkpath
+      end
+      @path = path.realdirpath
+    end
+
     def remove_from_project
-
+      pbx_file.remove_from_project
+      @pbx_file = nil
     end
 
-    def create_file_reference
-
-    end
-
-    private 
+    private
 
     def pbx_load
       @pbx_file = project.main_group.recursive_children.find { |g| g.real_path == path }
-    end
-
-    def insert_at_group(group)
-      find_or_create_relative_group(group, path.basename)
     end
   end
 end

--- a/lib/xcmv/file.rb
+++ b/lib/xcmv/file.rb
@@ -95,4 +95,24 @@ module XcodeMove
       @pbx_file = project.files.find{ |f| f.real_path == path }
     end
   end
+
+  class Directory < File
+    def remove_from_project
+
+    end
+
+    def create_file_reference
+
+    end
+
+    private 
+
+    def pbx_load
+      @pbx_file = project.main_group.recursive_children.find { |g| g.real_path == path }
+    end
+
+    def insert_at_group(group)
+      find_or_create_relative_group(group, path.basename)
+    end
+  end
 end

--- a/lib/xcmv/file.rb
+++ b/lib/xcmv/file.rb
@@ -20,9 +20,9 @@ module XcodeMove
       path.extname == '.h'
     end
 
-    def corresponding_dst(root_dst_path)
-      dst_path = root_dst_path + path.basename
-      self.class.new(dst_path) # want to return the same kind of object as the source
+    def with_dirname(root_path)
+      new_path = root_path + path.basename
+      self.class.new(new_path) # want to return the same kind of object
     end
 
     # Traverses up from the `path` to enumerate over xcodeproj directories
@@ -118,7 +118,7 @@ module XcodeMove
     private
 
     def pbx_load
-      @pbx_file = project.main_group.recursive_children.find { |g| g.real_path == path }
+      @pbx_file = project.main_group.recursive_children.find { |g| g.respond_to?(:real_path) and g.real_path == path }
     end
   end
 end


### PR DESCRIPTION
This change makes XcodeMove handle directories as sources in a more (imo) reasonable way.

Rather than treating the directory like every other file (creating a file reference for it then calling `mv <directory> <destination>`, etc), `xcmv` now recursively moves all the children of a directory (so subdirectories and subsubdirectories get handled appropriately, too) before removing the source directory from both the project file and the location on disk.

I appreciate feedback on how this has been implemented, as my gut says it can be better, but my brain is not able to land on what a better solution looks like.