### PR TITLE
Basic target membership inference implemented

### DIFF
--- a/lib/xcmv.rb
+++ b/lib/xcmv.rb
@@ -15,7 +15,7 @@ module XcodeMove
     if src.pbx_file
       src.remove_from_project
     else
-      warn("⚠️  Warning: #{src.path.basename} not found in #{src.project.path.basename}. moving anyway...")
+      warn("⚠️  Warning: #{src.path.basename} not found in #{src.project.path.basename}, moving anyway...")
     end
     if dst.pbx_file
       dst.remove_from_project

--- a/lib/xcmv.rb
+++ b/lib/xcmv.rb
@@ -15,7 +15,7 @@ module XcodeMove
     if src.pbx_file
       src.remove_from_project
     else
-      warn("warning: #{src.path.basename} not found in #{src.project.path.basename}. moving anyway...")
+      warn("⚠️  Warning: #{src.path.basename} not found in #{src.project.path.basename}. moving anyway...")
     end
     if dst.pbx_file
       dst.remove_from_project

--- a/lib/xcmv/file.rb
+++ b/lib/xcmv/file.rb
@@ -62,8 +62,9 @@ module XcodeMove
         if targets.empty?
           # fallback: if we can't infer any target membership,
           # we just assign the first target of the project and emit a warning
-          warn "⚠️  Warning: Unable to infer target membership of #{path} -- assigning to first target of project."
-          targets = [project.targets.select{ |t| t.respond_to?(:source_build_phase) }[0]]
+          fallback_target = project.targets.select{ |t| t.respond_to?(:source_build_phase) }[0] 
+          targets = [fallback_target]
+          warn "⚠️  Warning: Unable to infer target membership of #{path} -- assigning to #{fallback_target.name}."
         end
       else
         name_set = target_names.to_set

--- a/lib/xcmv/file.rb
+++ b/lib/xcmv/file.rb
@@ -50,32 +50,21 @@ module XcodeMove
       end
     end
 
-    def infer_target_membership
-      # attempt to infer target membership from sibling files
-      group = GroupMembership.new(pbx_file.parent)
-      targets = group.sibling_targets
-
-      # if we can't infer target membership from immediate siblings,
-      # we traverse up the project until we can, or we hit the main group
-      while targets.empty? && group.group != project.main_group do
-        group = GroupMembership.new(group.parent)
-        targets = group.sibling_targets
-      end
-
-      # fallback: if we can't infer any target membership by traveling up the project,
-      # we just assign the first target of the project and emit a warning
-      warn "⚠️  Warning: Unable to infer target membership of #{path} -- assigning to first target of project."
-      targets = [project.targets.select{ |t| t.respond_to?(:source_build_phase) }[0]] if targets.empty?
-      targets
-    end
-
     def add_to_targets(target_names, header_visibility)
       unless target_names
-        targets = infer_target_membership
+        group = GroupMembership.new(pbx_file.parent)
+        targets = group.inferred_targets
+
+        if targets.empty?
+          # fallback: if we can't infer any target membership,
+          # we just assign the first target of the project and emit a warning
+          warn "⚠️  Warning: Unable to infer target membership of #{path} -- assigning to first target of project."
+          targets = [project.targets.select{ |t| t.respond_to?(:source_build_phase) }[0]]
+        end
       else
         name_set = target_names.to_set
         targets = project.targets.select{ |t| name_set.include?(t.name) }
-        abort "No targets found in #{target_names}" if targets.empty?
+        abort "🛑  Error: No targets found in #{target_names}." if targets.empty?
       end
 
       targets.each do |target|

--- a/lib/xcmv/group_membership.rb
+++ b/lib/xcmv/group_membership.rb
@@ -9,12 +9,11 @@ end
 
 module XcodeMove
   class GroupMembership
-    attr_reader :group, :parent, :project
+    attr_reader :group, :project
     def initialize(group)
       @group = group
       @project = group.project
       @siblings = @group.children.to_set
-      @parent = @group == @project.main_group ? nil : @group.parent
     end
 
     # Returns an array of targets that the `group` should reasonably

--- a/lib/xcmv/group_membership.rb
+++ b/lib/xcmv/group_membership.rb
@@ -1,7 +1,7 @@
 
 module XcodeMove
   class GroupMembership
-    attr_reader :group, :parent
+    attr_reader :group, :parent, :project
     def initialize(group)
       @group = group
       @project = group.project
@@ -15,6 +15,20 @@ module XcodeMove
       compiled_targets.select{ |t| t.source_build_phase.files_references.any?{ |f| @siblings.include?(f) } }
     end
 
+    # Returns an array of targets that the `group` should reasonably
+    # belong to -- either based on `sibling_targets` or the `sibling_targets`
+    # of some ancestor group.
+    def inferred_targets
+      target_group = self
+      targets = Array.new
+      loop do
+        targets = target_group.sibling_targets
+        break unless targets.empty? && target_group.group != project.main_group
+        target_group = GroupMembership.new(target_group.parent)
+      end
+      targets
+    end
+        
     def max_header_visibility(target)
       sibling_headers = target.headers_build_phase.files.filter{ |f| @siblings.include?(file_ref) }
       sibling_headers.map{ |f| HeaderVisibility.from_file_settings(f.settings) }.max

--- a/lib/xcmv/group_membership.rb
+++ b/lib/xcmv/group_membership.rb
@@ -1,10 +1,12 @@
 
 module XcodeMove
   class GroupMembership
+    attr_reader :group, :parent
     def initialize(group)
       @group = group
       @project = group.project
       @siblings = @group.children.to_set
+      @parent = @group == @project.main_group ? nil : @group.parent
     end
 
     # Returns an array of targets that have build files in `group`.

--- a/lib/xcmv/group_membership.rb
+++ b/lib/xcmv/group_membership.rb
@@ -1,3 +1,11 @@
+class Xcodeproj::Project::Object::PBXGroup
+  # Returns an array of targets that have build files in `group`.
+  def sibling_targets
+    siblings = children.to_set
+    compiled_targets = project.targets.select{ |t| t.respond_to?(:source_build_phase) }
+    compiled_targets.select{ |t| t.source_build_phase.files_references.any?{ |f| siblings.include?(f) } }
+  end
+end
 
 module XcodeMove
   class GroupMembership
@@ -9,22 +17,15 @@ module XcodeMove
       @parent = @group == @project.main_group ? nil : @group.parent
     end
 
-    # Returns an array of targets that have build files in `group`.
-    def sibling_targets
-      compiled_targets = @project.targets.select{ |t| t.respond_to?(:source_build_phase) }
-      compiled_targets.select{ |t| t.source_build_phase.files_references.any?{ |f| @siblings.include?(f) } }
-    end
-
     # Returns an array of targets that the `group` should reasonably
     # belong to -- either based on `sibling_targets` or the `sibling_targets`
     # of some ancestor group.
     def inferred_targets
-      target_group = self
-      targets = Array.new
-      loop do
-        targets = target_group.sibling_targets
-        break unless targets.empty? && target_group.group != project.main_group
-        target_group = GroupMembership.new(target_group.parent)
+      target_group = self.group
+      targets = []
+      while targets.empty? and target_group.respond_to?(:sibling_targets) do
+        targets += target_group.sibling_targets
+        target_group = target_group.parent
       end
       targets
     end


### PR DESCRIPTION
This change adds better target membership inference for moved files. Before, `xcmv` would use the target membership of sibling files in the destination directory when moving a file. If the directory was empty, it would not set any target membership.

With this change, `xcmv` will traverse up the project directory until it can infer target membership from a group. If it reaches the project's main group without finding anything (or you're moving a file to a project's main group), it will emit a warning and just assign the moved file to the first of the project's targets.